### PR TITLE
テクスチャ編集ウィンドウがすぐ閉じる問題を修正

### DIFF
--- a/Editor/MaterialEditor/VisualElements/SCEditableTextureButton.cs
+++ b/Editor/MaterialEditor/VisualElements/SCEditableTextureButton.cs
@@ -42,7 +42,7 @@ namespace jp.lilxyzw.shadercore
                 var importer = AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(field.Property.textureValue)) as ImporterType;
                 var window = ScriptableObject.CreateInstance<EditorWindow>();
                 window.rootVisualElement.Add(Editor.CreateEditor(importer).CreateInspectorGUI());
-                window.ShowAuxWindow();
+                window.ShowUtility();
 
                 var e = SCUpdateEvent.GetPooled();
                 e.target = field;
@@ -52,7 +52,7 @@ namespace jp.lilxyzw.shadercore
             {
                 var window = ScriptableObject.CreateInstance<EditorWindow>();
                 window.rootVisualElement.Add(Editor.CreateEditor(importer).CreateInspectorGUI());
-                window.ShowAuxWindow();
+                window.ShowUtility();
             }
         }
     }


### PR DESCRIPTION
### 概要
マスクテクスチャの編集ウィンドウを開いた後、Projectからテクスチャを選ぼうとすると編集ウィンドウが閉じてしまう問題を修正しました。

### 原因
SCEditableTextureButtonで編集ウィンドウをShowAuxWindow()として表示していたため、ポップアップ以外を選択すると編集画面が閉じていました。

### 変更内容
編集画面をShowUtility()へ変更