### PR TITLE
refactor: alternative for local package folder

### DIFF
--- a/Editor/Utils/AssetUtils.cs
+++ b/Editor/Utils/AssetUtils.cs
@@ -1,7 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using UnityEditor.PackageManager;
 
 namespace jp.lilxyzw.shadercore
 {
@@ -10,24 +10,13 @@ namespace jp.lilxyzw.shadercore
         // AssetDatabaseを使わないアセットパス取得
         public static IEnumerable<string> GetFiles(string searchPattern)
         {
-            var directories = new List<string>(){"Assets/", "Packages/", "Library/PackageCache"};
-            if (File.Exists("Packages/manifest.json"))
+            var directories = new List<string>(){"Assets/"};
+            foreach (var package in PackageInfo.GetAllRegisteredPackages())
             {
-                var manifest = Newtonsoft.Json.JsonConvert.DeserializeObject<PackageManifest>(File.ReadAllText("Packages/manifest.json"));
-                var directory = "Packages";
-                directories.AddRange(manifest.dependencies.Select(kv => kv.Value).Where(p => p.StartsWith("file:")).Select(p => {
-                    try
-                    {
-                        var path = p[5..];
-                        if (Path.IsPathRooted(path)) return path;
-                        return "Packages/" + path;
-                    }
-                    catch
-                    {
-                        UnityEngine.Debug.LogError($"Invalid package path. {p}");
-                        return null;
-                    }
-                }).Where(p => !string.IsNullOrEmpty(p)));
+                if (package.source != PackageSource.BuiltIn && package.resolvedPath != null && Directory.Exists(package.resolvedPath))
+                {
+                    directories.Add(package.resolvedPath);
+                }
             }
             return directories.SelectMany(d => Directory.GetFiles(d, searchPattern, SearchOption.AllDirectories)).Select(p => p.Replace('\\', '/'));
         }
@@ -35,12 +24,6 @@ namespace jp.lilxyzw.shadercore
         public static IEnumerable<string> GetFiles(string searchPattern, string directory)
         {
             return Directory.GetFiles(directory, searchPattern, SearchOption.AllDirectories).Select(p => p.Replace('\\', '/'));
-        }
-
-        [Serializable]
-        private class PackageManifest
-        {
-            public Dictionary<string,string> dependencies = new();
         }
     }
 }


### PR DESCRIPTION
This is an alternative implementation for the issue I reported a couple days ago, but this does not parse the manifest file. If avoiding the use of `PackageInfo.GetAllRegisteredPackages()` was intentional, then this PR can be ignored.

In addition, this implementation skips Unity packages of type BuiltIn (com.unity.collections, com.unity.modules.vr, com.unity.render-pipelines.core, com.unity.shadergraph, ...) as they are unlikely to contain any files that Shader-Core is looking for, but this changes the meaning of `AssetUtils.GetFiles`, so the use of function might not be applicable outside of `jp.lilxyzw.shadercore`.

Packages of type Registry are still included out of caution because I think this includes the asset store (com.unity.burst, com.unity.addressables, com.unity.mathematics, com.unity.xr.openxr, ...).

The `Library/PackageCache` directory is no longer iterated as their full paths are returned by this alternative implementation.

As far as I could tell on my projects, the execution duration appears to be on-par with the previous implementation. This was tested with `.ToList()` on both implementations in order to force enumeration of the return value, with around ~90ms±10ms per `GetFiles(...).ToList()`.

I have checked that it is working in Unity 6.4 (6000.4.11f1) and Unity 2022 (2022.3.22f1), with NonToon installed through ALCOM (Embedded, in Packages/), NonToon installed through a `file:` reference (Local, in a full path), and NonToon installed through a .git URL (Git, in Library/PackageCache/)